### PR TITLE
Add #aboutcode to logged channels

### DIFF
--- a/pmxbot.conf
+++ b/pmxbot.conf
@@ -7,6 +7,7 @@ log_channels:
   - "#velociraptor"
   - "#pypa"
   - "#pypa-dev"
+  - "#aboutcode"
 server_host: irc.freenode.net
 server_port: 6697
 use_ssl: true


### PR DESCRIPTION
I was wondering if you could add #aboutcode to this bot. This is for https://github.com/nexB/scancode-toolkit/ and the http://aboutcode.org proper which are (fine) floss Python tools. 
Thank you for your consideration.
